### PR TITLE
BUGFIX: Fix crash when analyzing anonymous class instantiations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,11 @@
       "Wwwision\\TypesPhpStan\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Wwwision\\TypesPhpStan\\Tests\\": "tests/"
+    }
+  },
   "authors": [
     {
       "name": "bwaidelich",
@@ -38,6 +43,16 @@
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",
-    "wwwision/types": "^1"
+    "wwwision/types": "^1",
+    "phpunit/phpunit": "^12",
+    "phpstan/phpstan-phpunit": "^2"
+  },
+  "scripts": {
+    "test": "phpunit"
+  },
+  "config": {
+    "allow-plugins": {
+      "phpstan/extension-installer": true
+    }
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="PHPStan Rules Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/TypedClassesMustNotBeConstructedRule.php
+++ b/src/TypedClassesMustNotBeConstructedRule.php
@@ -7,6 +7,7 @@ namespace Wwwision\TypesPhpStan;
 use PhpParser\Node;
 use PhpParser\Node\Expr\New_;
 use PHPStan\Analyser\Scope;
+use PHPStan\Node\AnonymousClassNode;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
@@ -73,6 +74,12 @@ final readonly class TypedClassesMustNotBeConstructedRule implements Rule
         // Static class names: new Foo(), new \Fully\Qualified\Bar()
         if ($node->class instanceof Node\Name) {
             return [$scope->resolveName($node->class)];
+        }
+
+        // Anonymous classes: new class { ... }
+        // Anonymous classes can't have attributes, so we skip them
+        if ($node->class instanceof AnonymousClassNode) {
+            return [];
         }
 
         // Dynamic class names: new $className(), new ($var)(), new (self::class)()

--- a/tests/TypedClassesMustBeFinalRuleTest.php
+++ b/tests/TypedClassesMustBeFinalRuleTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Wwwision\TypesPhpStan\TypedClassesMustBeFinalRule;
+
+/**
+ * @extends RuleTestCase<TypedClassesMustBeFinalRule>
+ */
+final class TypedClassesMustBeFinalRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new TypedClassesMustBeFinalRule();
+    }
+
+    public function testFinalClassWithStringBasedAttributePasses(): void
+    {
+        $this->analyse([__DIR__ . '/data/FinalClassWithStringBased.php'], []);
+    }
+
+    public function testNonFinalClassWithStringBasedAttributeFails(): void
+    {
+        $this->analyse([__DIR__ . '/data/NonFinalClassWithStringBased.php'], [
+            [
+                'Class Wwwision\TypesPhpStan\Tests\Data\NonFinalClassWithStringBased is marked with #[StringBased] and must be declared as final. Add the final modifier to the class declaration.',
+                9,
+            ],
+        ]);
+    }
+
+    public function testNonFinalClassWithIntegerBasedAttributeFails(): void
+    {
+        $this->analyse([__DIR__ . '/data/NonFinalClassWithIntegerBased.php'], [
+            [
+                'Class Wwwision\TypesPhpStan\Tests\Data\NonFinalClassWithIntegerBased is marked with #[IntegerBased] and must be declared as final. Add the final modifier to the class declaration.',
+                9,
+            ],
+        ]);
+    }
+
+    public function testClassWithoutAttributePasses(): void
+    {
+        $this->analyse([__DIR__ . '/data/ClassWithoutAttribute.php'], []);
+    }
+}

--- a/tests/TypedClassesMustBeReadonlyRuleTest.php
+++ b/tests/TypedClassesMustBeReadonlyRuleTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Wwwision\TypesPhpStan\TypedClassesMustBeReadonlyRule;
+
+/**
+ * @extends RuleTestCase<TypedClassesMustBeReadonlyRule>
+ */
+final class TypedClassesMustBeReadonlyRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new TypedClassesMustBeReadonlyRule();
+    }
+
+    public function testReadonlyClassWithStringBasedAttributePasses(): void
+    {
+        $this->analyse([__DIR__ . '/data/ReadonlyClassWithStringBased.php'], []);
+    }
+
+    public function testNonReadonlyClassWithStringBasedAttributeFails(): void
+    {
+        $this->analyse([__DIR__ . '/data/NonReadonlyClassWithStringBased.php'], [
+            [
+                'Class Wwwision\TypesPhpStan\Tests\Data\NonReadonlyClassWithStringBased is marked with #[StringBased] and must be declared as readonly. Add the readonly modifier to the class declaration.',
+                9,
+            ],
+        ]);
+    }
+
+    public function testNonReadonlyClassWithFloatBasedAttributeFails(): void
+    {
+        $this->analyse([__DIR__ . '/data/NonReadonlyClassWithFloatBased.php'], [
+            [
+                'Class Wwwision\TypesPhpStan\Tests\Data\NonReadonlyClassWithFloatBased is marked with #[FloatBased] and must be declared as readonly. Add the readonly modifier to the class declaration.',
+                9,
+            ],
+        ]);
+    }
+
+    public function testClassWithoutAttributePasses(): void
+    {
+        $this->analyse([__DIR__ . '/data/ClassWithoutAttribute.php'], []);
+    }
+}

--- a/tests/TypedClassesMustHavePrivateConstructorRuleTest.php
+++ b/tests/TypedClassesMustHavePrivateConstructorRuleTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Wwwision\TypesPhpStan\TypedClassesMustHavePrivateConstructorRule;
+
+/**
+ * @extends RuleTestCase<TypedClassesMustHavePrivateConstructorRule>
+ */
+final class TypedClassesMustHavePrivateConstructorRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new TypedClassesMustHavePrivateConstructorRule();
+    }
+
+    public function testClassWithPrivateConstructorPasses(): void
+    {
+        $this->analyse([__DIR__ . '/data/ClassWithPrivateConstructor.php'], []);
+    }
+
+    public function testClassWithPublicConstructorFails(): void
+    {
+        $this->analyse([__DIR__ . '/data/ClassWithPublicConstructor.php'], [
+            [
+                'Class Wwwision\TypesPhpStan\Tests\Data\ClassWithPublicConstructor is marked with #[StringBased] and must have a private constructor, but it has a public constructor. Change the constructor visibility to private.',
+                9,
+            ],
+        ]);
+    }
+
+    public function testClassWithProtectedConstructorFails(): void
+    {
+        $this->analyse([__DIR__ . '/data/ClassWithProtectedConstructor.php'], [
+            [
+                'Class Wwwision\TypesPhpStan\Tests\Data\ClassWithProtectedConstructor is marked with #[IntegerBased] and must have a private constructor, but it has a protected constructor. Change the constructor visibility to private.',
+                9,
+            ],
+        ]);
+    }
+
+    public function testClassWithoutExplicitConstructorPasses(): void
+    {
+        $this->analyse([__DIR__ . '/data/ClassWithoutExplicitConstructor.php'], []);
+    }
+
+    public function testClassWithoutAttributePasses(): void
+    {
+        $this->analyse([__DIR__ . '/data/ClassWithoutAttribute.php'], []);
+    }
+}

--- a/tests/TypedClassesMustNotBeConstructedRuleTest.php
+++ b/tests/TypedClassesMustNotBeConstructedRuleTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Wwwision\TypesPhpStan\TypedClassesMustNotBeConstructedRule;
+
+/**
+ * @extends RuleTestCase<TypedClassesMustNotBeConstructedRule>
+ */
+final class TypedClassesMustNotBeConstructedRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new TypedClassesMustNotBeConstructedRule(
+            self::createReflectionProvider()
+        );
+    }
+
+    public function testDirectInstantiationOfStringBasedClassFails(): void
+    {
+        $this->analyse([__DIR__ . '/data/DirectInstantiationOfStringBased.php'], [
+            [
+                'Instantiation of class Wwwision\TypesPhpStan\Tests\Data\FinalClassWithStringBased is forbidden because it is marked with #[StringBased]. Use `Wwwision\Types\instantiate(Wwwision\TypesPhpStan\Tests\Data\FinalClassWithStringBased::class, $value)` instead.',
+                9,
+            ],
+        ]);
+    }
+
+    public function testDirectInstantiationOfIntegerBasedClassFails(): void
+    {
+        $this->analyse([__DIR__ . '/data/DirectInstantiationOfIntegerBased.php'], [
+            [
+                'Instantiation of class Wwwision\TypesPhpStan\Tests\Data\IntegerBasedClass is forbidden because it is marked with #[IntegerBased]. Use `Wwwision\Types\instantiate(Wwwision\TypesPhpStan\Tests\Data\IntegerBasedClass::class, $value)` instead.',
+                9,
+            ],
+        ]);
+    }
+
+    public function testDynamicInstantiationWithClassStringFails(): void
+    {
+        $this->analyse([__DIR__ . '/data/DynamicInstantiationWithClassString.php'], [
+            [
+                'Instantiation of class Wwwision\TypesPhpStan\Tests\Data\FinalClassWithStringBased is forbidden because it is marked with #[StringBased]. Use `Wwwision\Types\instantiate(Wwwision\TypesPhpStan\Tests\Data\FinalClassWithStringBased::class, $value)` instead.',
+                10,
+            ],
+        ]);
+    }
+
+    public function testInstantiationOfClassWithoutAttributePasses(): void
+    {
+        $this->analyse([__DIR__ . '/data/InstantiationOfClassWithoutAttribute.php'], []);
+    }
+}

--- a/tests/TypedClassesMustNotBeConstructedRuleTest.php
+++ b/tests/TypedClassesMustNotBeConstructedRuleTest.php
@@ -54,4 +54,9 @@ final class TypedClassesMustNotBeConstructedRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__ . '/data/InstantiationOfClassWithoutAttribute.php'], []);
     }
+
+    public function testAnonymousClassInstantiationPasses(): void
+    {
+        $this->analyse([__DIR__ . '/data/AnonymousClassInstantiation.php'], []);
+    }
 }

--- a/tests/data/AnonymousClassInstantiation.php
+++ b/tests/data/AnonymousClassInstantiation.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+interface SomeInterface
+{
+    public function method(): void;
+}
+
+class ClassWithAnonymousClass
+{
+    public function createAnonymousClass(): SomeInterface
+    {
+        return new class implements SomeInterface {
+            public function method(): void
+            {
+                // Implementation
+            }
+        };
+    }
+}

--- a/tests/data/ClassWithPrivateConstructor.php
+++ b/tests/data/ClassWithPrivateConstructor.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+use Wwwision\Types\Attributes\StringBased;
+
+#[StringBased]
+final readonly class ClassWithPrivateConstructor
+{
+    private function __construct(
+        public string $value,
+    ) {}
+}

--- a/tests/data/ClassWithProtectedConstructor.php
+++ b/tests/data/ClassWithProtectedConstructor.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+use Wwwision\Types\Attributes\IntegerBased;
+
+#[IntegerBased]
+final readonly class ClassWithProtectedConstructor
+{
+    protected function __construct(
+        public int $value,
+    ) {}
+}

--- a/tests/data/ClassWithPublicConstructor.php
+++ b/tests/data/ClassWithPublicConstructor.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+use Wwwision\Types\Attributes\StringBased;
+
+#[StringBased]
+final readonly class ClassWithPublicConstructor
+{
+    public function __construct(
+        public string $value,
+    ) {}
+}

--- a/tests/data/ClassWithoutAttribute.php
+++ b/tests/data/ClassWithoutAttribute.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+class ClassWithoutAttribute
+{
+    public function __construct(
+        public string $value,
+    ) {}
+}

--- a/tests/data/ClassWithoutExplicitConstructor.php
+++ b/tests/data/ClassWithoutExplicitConstructor.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+use Wwwision\Types\Attributes\ListBased;
+
+#[ListBased(itemClassName: \stdClass::class)]
+final readonly class ClassWithoutExplicitConstructor
+{
+    // No explicit constructor - this is valid
+}

--- a/tests/data/DirectInstantiationOfIntegerBased.php
+++ b/tests/data/DirectInstantiationOfIntegerBased.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+function testDirectInstantiationOfIntegerBased(): void
+{
+    new IntegerBasedClass();
+}

--- a/tests/data/DirectInstantiationOfStringBased.php
+++ b/tests/data/DirectInstantiationOfStringBased.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+function testDirectInstantiation(): void
+{
+    new FinalClassWithStringBased();
+}

--- a/tests/data/DynamicInstantiationWithClassString.php
+++ b/tests/data/DynamicInstantiationWithClassString.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+function testDynamicInstantiation(): void
+{
+    $className = FinalClassWithStringBased::class;
+    new $className();
+}

--- a/tests/data/FinalClassWithStringBased.php
+++ b/tests/data/FinalClassWithStringBased.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+use Wwwision\Types\Attributes\StringBased;
+
+#[StringBased]
+final readonly class FinalClassWithStringBased
+{
+    private function __construct(
+        public string $value,
+    ) {}
+}

--- a/tests/data/InstantiationOfClassWithoutAttribute.php
+++ b/tests/data/InstantiationOfClassWithoutAttribute.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+function testInstantiationOfNormalClass(): void
+{
+    new ClassWithoutAttribute('test');
+}

--- a/tests/data/IntegerBasedClass.php
+++ b/tests/data/IntegerBasedClass.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+use Wwwision\Types\Attributes\IntegerBased;
+
+#[IntegerBased]
+final readonly class IntegerBasedClass
+{
+    private function __construct(
+        public int $value,
+    ) {}
+}

--- a/tests/data/NonFinalClassWithIntegerBased.php
+++ b/tests/data/NonFinalClassWithIntegerBased.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+use Wwwision\Types\Attributes\IntegerBased;
+
+#[IntegerBased]
+readonly class NonFinalClassWithIntegerBased
+{
+    private function __construct(
+        public int $value,
+    ) {}
+}

--- a/tests/data/NonFinalClassWithStringBased.php
+++ b/tests/data/NonFinalClassWithStringBased.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+use Wwwision\Types\Attributes\StringBased;
+
+#[StringBased]
+readonly class NonFinalClassWithStringBased
+{
+    private function __construct(
+        public string $value,
+    ) {}
+}

--- a/tests/data/NonReadonlyClassWithFloatBased.php
+++ b/tests/data/NonReadonlyClassWithFloatBased.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+use Wwwision\Types\Attributes\FloatBased;
+
+#[FloatBased]
+final class NonReadonlyClassWithFloatBased
+{
+    private function __construct(
+        public readonly float $value,
+    ) {}
+}

--- a/tests/data/NonReadonlyClassWithStringBased.php
+++ b/tests/data/NonReadonlyClassWithStringBased.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+use Wwwision\Types\Attributes\StringBased;
+
+#[StringBased]
+final class NonReadonlyClassWithStringBased
+{
+    private function __construct(
+        public readonly string $value,
+    ) {}
+}

--- a/tests/data/ReadonlyClassWithStringBased.php
+++ b/tests/data/ReadonlyClassWithStringBased.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\TypesPhpStan\Tests\Data;
+
+use Wwwision\Types\Attributes\StringBased;
+
+#[StringBased]
+final readonly class ReadonlyClassWithStringBased
+{
+    private function __construct(
+        public string $value,
+    ) {}
+}


### PR DESCRIPTION
Anonymous classes were causing a TypeError in `TypedClassesMustNotBeConstructedRule` because the code attempted to call `getType()` on `AnonymousClassNode`, which expects an `Expr` node type instead.

The fix adds a check to detect and skip anonymous classes (which can't have `TypeBased` attributes anyway) before attempting to extract their type information.

Fixes #1